### PR TITLE
Remove non-compiling, seemingly unneeded code. Fix include.

### DIFF
--- a/pression/pluginRegistry.cpp
+++ b/pression/pluginRegistry.cpp
@@ -59,7 +59,7 @@ public:
             directories.push_back( getcwd( cwd, MAXPATHLEN ));
 
 #ifdef _WIN32
-        if( GetModuleFileName( 0, cwd, MAXPATHLEN ) > 0 )
+            if( GetModuleFileName( 0, cwd, MAXPATHLEN ) > 0 )
                 directories.push_back( lunchbox::getDirname( cwd ));
 #else
 #  ifdef Darwin

--- a/pression/pluginRegistry.cpp
+++ b/pression/pluginRegistry.cpp
@@ -30,7 +30,7 @@
 #include <lunchbox/file.h>
 
 #ifdef _WIN32
-#  include "lunchbox/os.h" // GetModuleFileName
+#  include <lunchbox/os.h> // GetModuleFileName
 #  include <direct.h>
 #  define getcwd _getcwd
 #else
@@ -59,11 +59,8 @@ public:
             directories.push_back( getcwd( cwd, MAXPATHLEN ));
 
 #ifdef _WIN32
-            //rgh: does not compile, and seems to be handled by code above.
-            /*
-            if( GetModuleFileName( 0, cwd, MAXPATHLEN ) > 0 )
-                directories.push_back( pression::getDirname( cwd ));
-                */
+        if( GetModuleFileName( 0, cwd, MAXPATHLEN ) > 0 )
+                directories.push_back( lunchbox::getDirname( cwd ));
 #else
 #  ifdef Darwin
             env = getenv( "DYLD_LIBRARY_PATH" );

--- a/pression/pluginRegistry.cpp
+++ b/pression/pluginRegistry.cpp
@@ -30,7 +30,7 @@
 #include <lunchbox/file.h>
 
 #ifdef _WIN32
-#  include "os.h" // GetModuleFileName
+#  include "lunchbox/os.h" // GetModuleFileName
 #  include <direct.h>
 #  define getcwd _getcwd
 #else
@@ -59,8 +59,11 @@ public:
             directories.push_back( getcwd( cwd, MAXPATHLEN ));
 
 #ifdef _WIN32
+            //rgh: does not compile, and seems to be handled by code above.
+            /*
             if( GetModuleFileName( 0, cwd, MAXPATHLEN ) > 0 )
                 directories.push_back( pression::getDirname( cwd ));
+                */
 #else
 #  ifdef Darwin
             env = getenv( "DYLD_LIBRARY_PATH" );


### PR DESCRIPTION
It may be required that in line 62, code to get the %path% environment
variable is put.